### PR TITLE
Typo fixes

### DIFF
--- a/languages/en/Encyclopedia/Creatures.xml
+++ b/languages/en/Encyclopedia/Creatures.xml
@@ -1510,13 +1510,13 @@
    <color r="1" g="1" b="1"/>
    <text>                   Unicorn</text><nl/><nl/>
    <size>Medium</size><color r="0.5" g="0.9" b="1"/>
-   <text> Unicorns</text>
+   <text> Unicorn</text>
    <nlkx/>
    <text> </text>
    <color r="0.9" g="0.9" b="0.9"/>
    <nlkx/>
    <text> A stunningly beautiful white horse, with a single horn</text><nlkx/>
-   <text> in its foreheads.</text>
+   <text> in its forehead.</text>
    <nl/><nl/>
    <text> The Unicorn can't be attacked.</text>
    <nl/><nl/><nl/><nl/>

--- a/languages/en/Encyclopedia/Creatures.xml
+++ b/languages/en/Encyclopedia/Creatures.xml
@@ -1516,7 +1516,7 @@
    <color r="0.9" g="0.9" b="0.9"/>
    <nlkx/>
    <text> A stunningly beautiful white horse, with a single horn</text><nlkx/>
-   <text> in its forehead.</text>
+   <text> on its forehead.</text>
    <nl/><nl/>
    <text> The Unicorn can't be attacked.</text>
    <nl/><nl/><nl/><nl/>

--- a/languages/en/Encyclopedia/Creatures.xml
+++ b/languages/en/Encyclopedia/Creatures.xml
@@ -1144,7 +1144,7 @@
    <color r="1" g="1" b="1"/>
    <text>           Mountain Chimeran Wolves</text><nl/><nl/>
    <size>Medium</size><color r="0.5" g="0.9" b="1"/>
-   <text> Moutain Chimeran Wolves</text>
+   <text> Mountain Chimeran Wolves</text>
    <nlkx/>
    <text> </text>
    <color r="0.9" g="0.9" b="0.9"/>


### PR DESCRIPTION
A few minor typo fixes. Changing "Unicorns" to "Unicorn" was done since according to the lore there is only one unicorn. I heard there is some sort of monster only occuring in invasions or instances that can temporarily transform into one, but that should not really count here in my opinion.